### PR TITLE
Fix Playlist order from Spotify Library not being used

### DIFF
--- a/frontend/spotify_manager.py
+++ b/frontend/spotify_manager.py
@@ -44,9 +44,10 @@ class UserArtist():
         return self.name
 
 class UserPlaylist(): 
-    __slots__ = ['name', 'uri', 'track_count']
-    def __init__(self, name, uri, track_count):
+    __slots__ = ['name', 'idx', 'uri', 'track_count']
+    def __init__(self, name, idx, uri, track_count):
         self.name = name
+        self.idx = idx
         self.uri = uri
         self.track_count = track_count
 
@@ -98,7 +99,7 @@ def get_playlist(id):
     for _, item in enumerate(results['tracks']['items']):
         track = item['track']
         tracks.append(UserTrack(track['name'], track['artists'][0]['name'], track['album']['name'], track['uri']))
-    return (UserPlaylist(results['name'], results['uri'], len(tracks)), tracks)
+    return (UserPlaylist(results['name'], results['index'], results['uri'], len(tracks)), tracks)
 
 def get_album(id):
     # TODO optimize query
@@ -185,17 +186,20 @@ def refresh_data():
     print("Spotify artists fetched: " + str(DATASTORE.getArtistCount()))
 
     results = sp.current_user_playlists(limit=pageSize)
+    totalindex = 0 # variable to preserve playlist sort index when calling offset loop down below
     while(results['next']):
         offset = results['offset']
         for idx, item in enumerate(results['items']):
             tracks = get_playlist_tracks(item['id'])
-            DATASTORE.setPlaylist(UserPlaylist(item['name'], item['uri'], len(tracks)), tracks, index=idx + offset)
+            DATASTORE.setPlaylist(UserPlaylist(item['name'], totalindex, item['uri'], len(tracks)), tracks, index=idx + offset)
+            totalindex = totalindex + 1
         results = sp.next(results)
 
     offset = results['offset']
     for idx, item in enumerate(results['items']):
         tracks = get_playlist_tracks(item['id'])
-        DATASTORE.setPlaylist(UserPlaylist(item['name'], item['uri'], len(tracks)), tracks, index=idx + offset)
+        DATASTORE.setPlaylist(UserPlaylist(item['name'], totalindex, item['uri'], len(tracks)), tracks, index=idx + offset)
+        totalindex = totalindex + 1
 
     print("Spotify playlists fetched: " + str(DATASTORE.getPlaylistCount()))
 

--- a/frontend/view_model.py
+++ b/frontend/view_model.py
@@ -282,12 +282,20 @@ class PlaylistsPage(MenuPage):
         super().__init__(self.get_title(), previous_page, has_sub_page=True)
         self.playlists = self.get_content()
         self.num_playlists = len(self.playlists)
+                
+        self.playlists.sort(key=self.get_idx) # sort playlists to keep order as arranged in Spotify library
 
     def get_title(self):
         return "Playlists"
 
     def get_content(self):
         return spotify_manager.DATASTORE.getAllSavedPlaylists()
+
+    def get_idx(self, e): # function to get idx from UserPlaylist for sorting
+        if type(e) == spotify_manager.UserPlaylist: # self.playlists also contains albums as it seems and they don't have the idx value
+            return e.idx
+        else:
+            return 0
 
     def total_size(self):
         return self.num_playlists


### PR DESCRIPTION
Hey!  
This commit fixes the Playlist list not appearing in the same order as in your Spotify Library.  

**How:**
I did this by adding a new `idx` parameter to the `UserPlaylist` class.  
This parameter is getting fed by a totalindex variable that counts all iterations of the first and the second (offset) loop which fetch the users playlist data in `frontend/spotify_manager.py`.  
The init function of the `PlaylistPage` class in `view_model.py` then sorts the playlists list by getting the `idx` of each playlist from the `UserPlaylist` class using the added `get_idx()` function.  

When fetching all playlists using spotipy in `refresh_data()` the order of supplied playlists was always the same as in the users Spotify library. But this order wasn't kept in the list and therefore also not in the Playlists menu.  

Note: Deleting pycache and calling refresh_data() once is necessary.  

Another note:  
This pull request does not include my changes from [my other pull request](https://github.com/dupontgu/retro-ipod-spotify-client/pull/24) so if that should get accepted do I then need to add those changes to this branch too? Otherwise they would get reset by this pull request or am I wrong? That would be no problem to do but I just want to ask before doing something stupid and combining these two pull requests together didn't seem logical for me as they address different issues.    
Sorry, I haven't worked with pull requests that much.  