### PR TITLE
click.c fix -Wmain warnings

### DIFF
--- a/clickwheel/click.c
+++ b/clickwheel/click.c
@@ -157,7 +157,7 @@ void onDataEdge(int gpio, int level, uint32_t tick) {
     dataBit = level;
 }
 
-int main(void *args){
+int main(int argc, char** argv){
   
     // Creating socket file descriptor 
     if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) { 


### PR DESCRIPTION
this pull request will remove following warnings:

```
click.c:160:5: warning: first argument of 'main' should be 'int' [-Wmain]
 int main(void *args){
     ^~~~
click.c:160:5: warning: 'main' takes only zero or two arguments [-Wmain]

```